### PR TITLE
Remove underline from navigation buttons

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -56,6 +56,8 @@ section.puzzle {
 .variant-wordle32 .all-guess-row .solution-box.rating-misplaced { background-color: #b59f3b; color: #fff; }
 .variant-wordle32 .all-guess-row .solution-box.rating-wrong { background-color: #3a3a3c; color: #fff; }
 
+p.date-nav a { text-decoration: none; }
+
 @media screen and (prefers-color-scheme: dark) {
   body { background-color: black; color: #ccc; }
   input[type=text], input[type=number], select, textarea { background-color: black; color: #ccc; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
 <title>{% block title %}Untitled{% endblock %}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="generator" content="wordle-archive" />
-<link rel="stylesheet" href="{{ static_prefix }}/style.css?20220627-01" />
+<link rel="stylesheet" href="{{ static_prefix }}/style.css?20221015-01" />
 {% block addhead %}
 {% endblock %}
 </head>


### PR DESCRIPTION
I think the navigation buttons are more beautiful without the underline.

Before:

![image](https://user-images.githubusercontent.com/404840/195956177-005d4da7-63f7-4e76-88ca-592023ebba5a.png)

After:

![image](https://user-images.githubusercontent.com/404840/195956185-cca86ab2-942e-450d-94f7-4de7c56f3e17.png)
