### PR TITLE
Fix victory check

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -443,7 +443,7 @@ fn db_puzzle_to_puzzle_part(db_puzzle: &SiteAndPuzzle) -> PuzzlePart {
             .collect();
         let solution = solution_lines.get(solution_lines.len() - sub_puzzle_patterns.len() + i)
             .unwrap().clone();
-        let victory = pattern_lines.iter().any(|ln| ln.chars().all(|c| [ 'M', 'W', '1', '2', '3', '4', '5' ].contains(&c)));
+        let victory = pattern_lines.iter().any(|ln| ln.chars().all(|c| ![ 'M', 'W', '1', '2', '3', '4', '5' ].contains(&c)));
 
         sub_puzzles.push(SubPuzzle {
             pattern_lines,


### PR DESCRIPTION
Commit [06b1c06](https://github.com/RavuAlHemio/wordle-archive/commit/06b1c06218112b684f690fd3b44ab84de2dcec3d) broke the check for a victory. This made Wordle Archive unnecessarily add a solution line in "spoil" mode in some cases:

![fi0LS0vyCt0lqciu](https://user-images.githubusercontent.com/404840/218146047-8548f298-fbb3-408a-865f-4e3b71f17f06.png)

This PR fixes this problem:

![image](https://user-images.githubusercontent.com/404840/218146308-b49eb121-70ed-43cd-b2ee-65ae714ea999.png)
