### PR TITLE
support intro page of NYT's wordle

### DIFF
--- a/tampermonkey/nyt-wordle-copy-guesses.user.js
+++ b/tampermonkey/nyt-wordle-copy-guesses.user.js
@@ -72,11 +72,12 @@
     var navBarCount = 0;
     waitAndGiveNavBar = function () {
         var navBar = document.querySelector(".wordle-app-header div[class^=AppHeader-module_menuRight__]");
-        if (navBar === null && navBarCount < 5) {
-            navBarCount += 1;
-            window.setTimeout(waitAndGiveNavBar, 200);
+        if (navBar === null) {
+            window.setTimeout(waitAndGiveNavBar, 1000);
         }
-        setUpButton(navBar);
+        else {
+            setUpButton(navBar);
+        }
     };
-    window.setTimeout(waitAndGiveNavBar, 200);
+    window.setTimeout(waitAndGiveNavBar, 1000);
 })();


### PR DESCRIPTION
Since a few days, NYT's wordle comes with a new intro page where one needs to click a button to reach the actual puzzle. As long as this button has not been clicked, it is not possible to add the "copy guesses" button.